### PR TITLE
Fix a bug with autocompleting namespaced objects

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -21,6 +21,7 @@ export function parseSuggestions(suggestions: string, prefix: string): Array<Obj
     const firstSpace = chunk.indexOf(' ')
 
     let type = 'property'
+    let displayText
     const replacement = chunk.substr(0, firstSpace)
     const description = chunk.substr(firstSpace + 1) || '_'
     const label = REGEX_LABEL.exec(description)[0]
@@ -38,10 +39,13 @@ export function parseSuggestions(suggestions: string, prefix: string): Array<Obj
       let number = 0
       const regex = /(\$\w+)/g
       snippet = []
+      const displayTextArgs = []
       while ((match = regex.exec(description)) !== null) { // eslint-disable-line
         snippet.push(`\${${++ number}:${match[0]}}`)
+        displayTextArgs.push(match[0])
       }
-      snippet = `${replacement}(${snippet.join(', ')}\${${++number}})`
+      displayText = `${replacement}(${displayTextArgs.join(', ')})`
+      snippet = `${replacement.replace(/\\/g, '\\\\')}(${snippet.join(', ')}\${${++number}})`
     }
     const score = stringScore(chunk, prefix)
     if (prefix !== '' && score === 0) {
@@ -53,6 +57,7 @@ export function parseSuggestions(suggestions: string, prefix: string): Array<Obj
       leftLabel: label,
       description,
       text: !snippet && replacement,
+      displayText,
       snippet,
       replacementPrefix: prefix,
       score: stringScore(chunk, prefix),

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,7 @@ import stringScore from 'sb-string_score'
 import type { TextEditor, Point } from 'atom'
 
 const REGEX_LABEL = /(\w+)/
-const REGEX_PREFIX = /((:\w[\w:-]+)|(\$\w*)|::(\w+)|(\w+))$/
+const REGEX_PREFIX = /((:\w[\w:-]+)|(\$\w*)|::(\w+)|([\w\\]+))$/
 
 export function getTransformedText(textEditor: TextEditor, bufferPosition: Point): string {
   const textBuffer = textEditor.getBuffer()


### PR DESCRIPTION
```
MongoDB\[TAB]
```

would result in `MongoDB\MongoDB\BSON\Something`
This change fixes that
